### PR TITLE
LIOS changes v1

### DIFF
--- a/lios/editor.py
+++ b/lios/editor.py
@@ -79,7 +79,18 @@ class BasicTextView(text_view.TextView):
 		#while pressing undo or redo that again trigger
 		# insert or delete signals - Nalin.x.GNU
 		self.push_change_to_undobuffer = True;
-	
+	def insert_text_with_line_numbers(self, text):
+		lines = text.split('\n')
+		numbered_lines = []
+		line_number = 1
+		for line in lines:
+			if line.strip():  # Only number non-empty lines
+				numbered_lines.append(f"{line_number}: {line}")
+				line_number += 1
+			else:
+				numbered_lines.append(line)  # Keep empty lines as is
+		self.set_text('\n'.join(numbered_lines))
+		self.set_modified(True)
 	def set_dictionary(self,dict):
 		self.dict = dict
 	

--- a/lios/editor.py
+++ b/lios/editor.py
@@ -741,22 +741,20 @@ class BasicTextView(text_view.TextView):
 		window1.show_all()
 
 	
-	def go_to_line(self,*data):
-		current_line = self.get_cursor_line_number()
-		maximum_line = self.get_line_count()		
-		spinbutton_line = widget.SpinButton(current_line,0,maximum_line,1,5,0)
+	def go_to_line(self, *data):
+		current_line = self.count_non_empty_lines()
+		spinbutton_line = widget.SpinButton(1, 1, current_line, 1, 5, 0)
 		
-		dlg = dialog.Dialog(_("Go To Line"),(_("Go"), dialog.Dialog.BUTTON_ID_1,_("Close!"), dialog.Dialog.BUTTON_ID_2))
-		#spinbutton_line.connect("activate",lambda x : dialog.response(Gtk.ResponseType.ACCEPT))
-		dlg.add_widget_with_label(spinbutton_line,_("Line Number: "))
+		dlg = dialog.Dialog(_("Go To Line"), (_("Go"), dialog.Dialog.BUTTON_ID_1, _("Close!"), dialog.Dialog.BUTTON_ID_2))
+		dlg.add_widget_with_label(spinbutton_line, _("Line Number: "))
 		spinbutton_line.grab_focus()
 		dlg.show_all()
 		response = dlg.run()
 		
 		if response == dialog.Dialog.BUTTON_ID_1:
-			to = spinbutton_line.get_value()
-			self.move_cursor_to_line(to)
-			self.highlights_cursor_line()
+			to = int(spinbutton_line.get_value())
+			if self.move_cursor_to_non_empty_line(to):
+				self.highlights_cursor_line()
 			dlg.destroy()
 		else:
 			dlg.destroy()

--- a/lios/macros.py
+++ b/lios/macros.py
@@ -63,6 +63,8 @@ source_link = "https://gitlab.com/Nalin-x-Linux/lios-3"
 
 home_page_link = "http://sourceforge.net/projects/lios/"
 
+readme_page_link="readme.html"
+
 video_tutorials_link = "https://www.youtube.com/playlist?list=PLn29o8rxtRe1zS1r2-yGm1DNMOZCgdU0i"
 
 major_character_encodings_list = [ 'us_ascii', 'utf-8', 'iso_8859_1','latin1',

--- a/lios/macros.py
+++ b/lios/macros.py
@@ -61,7 +61,7 @@ app_name_abbreviated = "lios"
 
 source_link = "https://gitlab.com/Nalin-x-Linux/lios-3"
 
-home_page_link = "http://sourceforge.net/projects/lios/"
+home_page_link = "https://www.zendalona.com/lios"
 
 readme_page_link="readme.html"
 

--- a/lios/main.py
+++ b/lios/main.py
@@ -1063,21 +1063,24 @@ class linux_intelligent_ocr_solution():
 		self.available_ocr_engine_list[self.preferences.ocr_engine].cancel()
 		self.notify_information(_("Terminated"),0)
 		
+	# def open_readme(self,*data):
+	# 	if(self.textview.get_modified()):
+	# 		dlg = dialog.Dialog(_("Warning!"),
+	# 		 (_("No"),dialog.Dialog.BUTTON_ID_1,_("Yes"),dialog.Dialog.BUTTON_ID_2))
+	# 		label = widget.Label(_("Current text not saved! do you want to load readme without saving?"))
+	# 		label.show()
+	# 		dlg.add_widget(label)
+	# 		response = dlg.run()
+	# 		if response == dialog.Dialog.BUTTON_ID_2:
+	# 			with open(macros.readme_file) as file:
+	# 				self.textview.set_text(file.read())
+	# 		dlg.destroy()
+	# 	else:
+	# 		with open(macros.readme_file) as file:
+	# 			self.textview.set_text(file.read())
 	def open_readme(self,*data):
-		if(self.textview.get_modified()):
-			dlg = dialog.Dialog(_("Warning!"),
-			 (_("No"),dialog.Dialog.BUTTON_ID_1,_("Yes"),dialog.Dialog.BUTTON_ID_2))
-			label = widget.Label(_("Current text not saved! do you want to load readme without saving?"))
-			label.show()
-			dlg.add_widget(label)
-			response = dlg.run()
-			if response == dialog.Dialog.BUTTON_ID_2:
-				with open(macros.readme_file) as file:
-					self.textview.set_text(file.read())
-			dlg.destroy()
-		else:
-			with open(macros.readme_file) as file:
-				self.textview.set_text(file.read())
+		webbrowser.open(macros.readme_page_link)
+     
 
 
 	@on_thread			

--- a/lios/main.py
+++ b/lios/main.py
@@ -273,7 +273,7 @@ class linux_intelligent_ocr_solution():
 		menubar.show()
 
 		self.combobox_scanners = widget.ComboBox()
-		button_update_scanner_list = widget.Button(_("Update Scanner List"))
+		button_update_scanner_list = widget.Button(_("Detect Scanners"))
 		button_update_scanner_list.connect_function(self.update_scanner_list)
 		button_scan = widget.Button(_("Scan"))
 		button_scan.connect_function(self.scan_single_image)		

--- a/lios/main.py
+++ b/lios/main.py
@@ -103,8 +103,8 @@ class linux_intelligent_ocr_solution():
 		self.imageview.connect("list_updated",self.list_updated_event_handler);
 		self.imageview.set_vexpand(True)
 		self.imageview.set_hexpand(True)
-		box_imageview = containers.Box(containers.Box.HORIZONTAL)
-		toolbar_imageview = containers.Toolbar(containers.Toolbar.VERTICAL,
+		box_imageview = containers.Box(containers.Box.VERTICAL)
+		toolbar_imageview = containers.Toolbar(containers.Toolbar.HORIZONTAL,
 			[(_("Rotate-Right"),self.rotate_current_images_to_right),
 			(_("Rotate-Twice"),self.rotate_current_images_to_twice),
 			(_("Rotate-Left"),self.rotate_current_images_to_left),containers.Toolbar.SEPARATOR,
@@ -137,8 +137,8 @@ class linux_intelligent_ocr_solution():
 		self.textview.set_vexpand(True)
 		self.textview.set_hexpand(True)		
 		self.textview.set_accepts_tab(False)
-		box_editor = containers.Box(containers.Box.HORIZONTAL)
-		toolbar_editor = containers.Toolbar(containers.Toolbar.VERTICAL,
+		box_editor = containers.Box(containers.Box.VERTICAL)
+		toolbar_editor = containers.Toolbar(containers.Toolbar.HORIZONTAL,
 			[(_("New"),self.new),(_('Open'),self.open_files),
 			(_("Save"),self.textview.save),containers.Toolbar.SEPARATOR,
 			(_("Spell-Check"),self.textview.open_spell_check),containers.Toolbar.SEPARATOR,

--- a/lios/main.py
+++ b/lios/main.py
@@ -277,11 +277,7 @@ class linux_intelligent_ocr_solution():
 		button_update_scanner_list.connect_function(self.update_scanner_list)
 		button_scan = widget.Button(_("Scan"))
 		button_scan.connect_function(self.scan_single_image)		
-		toolbar_main = containers.Toolbar(containers.Toolbar.HORIZONTAL,
-			[(_("Preferences"),self.open_preferences_general_page),
-			(_("Video Tutorials"),self.open_video_tutorials),
-			(_("About"),self.about),
-			(_("Quit"),self.quit)])				
+						
 		
 		#Slide Panes
 		self.paned_image_text = containers.Paned(containers.Paned.VERTICAL)
@@ -304,7 +300,6 @@ class linux_intelligent_ocr_solution():
 			(self.combobox_scanners,1,1,containers.Grid.HEXPAND,containers.Grid.NO_VEXPAND),
 			(button_update_scanner_list,1,1,containers.Grid.HEXPAND,containers.Grid.NO_VEXPAND),
 			(button_scan,1,1,containers.Grid.HEXPAND,containers.Grid.NO_VEXPAND),
-			(toolbar_main,2,1,containers.Grid.HEXPAND,containers.Grid.NO_VEXPAND,containers.Grid.ALIGN_END),
 			containers.Grid.NEW_ROW,
 			(self.paned_main,5,1),
 			containers.Grid.NEW_ROW,

--- a/lios/preferences.py
+++ b/lios/preferences.py
@@ -514,7 +514,7 @@ class lios_preferences:
 		grid_scanning.add_widgets([
 			(label_resolution,1,1),(spin_resolution,1,1),containers.Grid.NEW_ROW,
 			(label_brightness,1,1),(spin_brightness,1,1),containers.Grid.NEW_ROW,
-			(label_scan_area,1,1),(combobox_scan_area,1,1),containers.Grid.NEW_ROW,
+			# (label_scan_area,1,1),(combobox_scan_area,1,1),containers.Grid.NEW_ROW,
 			(label_scan_driver,1,1),(combobox_scan_driver,1,1),containers.Grid.NEW_ROW,
 			(sparator_3,2,1),containers.Grid.NEW_ROW,
 			(label_number_of_pages_to_scan,1,1),(spin_number_of_pages_to_scan,1,1),containers.Grid.NEW_ROW,

--- a/lios/readme.html
+++ b/lios/readme.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <meta charset="UTF-8">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <title>Linux-Intelligent-OCR-Solution (Lios)</title>
+   <style>
+       body {
+           font-family: Arial, sans-serif;
+           line-height: 1.6;
+           color: #333;
+           max-width: 800px;
+           margin: 0 auto;
+           padding: 20px;
+           background-color: #f4f4f4;
+       }
+       h1, h2 {
+           color: #2c3e50;
+       }
+       h1 {
+           text-align: center;
+           border-bottom: 2px solid #2c3e50;
+           padding-bottom: 10px;
+       }
+       h2 {
+           margin-top: 30px;
+       }
+       ul {
+           padding-left: 20px;
+       }
+       .feature-list {
+           background-color: #ecf0f1;
+           padding: 20px;
+           border-radius: 5px;
+       }
+       .disclaimer {
+           font-size: 0.9em;
+           background-color: #e74c3c;
+           color: white;
+           padding: 10px;
+           border-radius: 5px;
+           margin-top: 30px;
+       }
+   </style>
+</head>
+<body>
+   <h1>Linux-Intelligent-OCR-Solution (Lios)</h1>
+
+
+   <h2>What is Lios?</h2>
+   <p>Lios is a free and open source software for converting print into text using either a scanner or a camera. It can also produce text out of scanned images from other sources such as PDF, Image, Folder containing Images or screenshot. The program is given total accessibility for visually impaired. Lios is written in Python 3 and released under the GPL-3 license.</p>
+
+
+   <h2>Features of Lios</h2>
+   <div class="feature-list">
+       <ul>
+           <li>Import images from Scanner, PDFs, Folder, or Webcam</li>
+           <li>Take and Recognize Screenshot</li>
+           <li>Recognize Selected Areas (Rectangle selection)</li>
+           <li>Support two OCR Engines (Cuneiform, Tesseract)</li>
+           <li>24 Language support (30 more languages can be installed in Tesseract)</li>
+           <li>Full Auto Rotation for any Language</li>
+           <li>Side by side view of image and output</li>
+           <li>Advanced Scanner Brightness optimizer</li>
+           <li>Text Reader for low vision with Highlighting</li>
+           <li>Audio converter (espeak)</li>
+           <li>Spell-checker (aspell)</li>
+           <li>Export as PDF (text/images)</li>
+           <li>Dictionary Support for English (Artha)</li>
+           <li>Options for save, load and reset settings</li>
+       </ul>
+   </div>
+
+
+   <h2>Opening and Closing</h2>
+   <p>To open Lios, launch Application menu > Graphics > Lios. Or search in the dashboard and start Lios from there. To close, select Quit from File menu or press Ctrl+Q.</p>
+
+
+   <h2>Importing Images</h2>
+   <p>Lios supports importing images from various sources, including:</p>
+   <ul>
+       <li>Single or multiple image files</li>
+       <li>PDF files</li>
+       <li>Folders containing images</li>
+       <li>Scanner</li>
+       <li>Screenshot</li>
+       <li>Webcam</li>
+   </ul>
+
+
+   <h2>OCR and Text Manipulation</h2>
+   <p>Lios offers various OCR options and text manipulation tools, including:</p>
+   <ul>
+       <li>OCR with and without rotation</li>
+       <li>Rectangle selection for OCR</li>
+       <li>Text editing tools (cut, copy, paste, delete)</li>
+       <li>Find and Replace</li>
+       <li>Spell checker</li>
+       <li>Text reader with TTS</li>
+   </ul>
+
+
+   <h2>Utilities</h2>
+   <p>Lios includes several useful utilities:</p>
+   <ul>
+       <li>Brightness Optimizer for scanner</li>
+       <li>Audio converter</li>
+       <li>Artha dictionary integration</li>
+   </ul>
+
+
+   <div class="disclaimer">
+       <h2>Disclaimer</h2>
+       <p>Lios is free software released under the GPL-3 license. It is distributed without any warranty. For full license details, please refer to the GNU General Public License version 3.</p>
+   </div>
+</body>
+</html>
+

--- a/lios/ui/gtk/text_view.py
+++ b/lios/ui/gtk/text_view.py
@@ -175,17 +175,42 @@ class TextView(Gtk.TextView):
 		start_iter.backward_sentence_start()
 		end_iter.forward_to_line_end()
 		return buffer.get_text(start_iter,end_iter,True)		
-	
+	def count_non_empty_lines(self, up_to_line=None):
+		buffer = self.get_buffer()
+		count = 0
+		for line in range(buffer.get_line_count()):
+			if up_to_line is not None and line > up_to_line:
+				break
+			iter = buffer.get_iter_at_line(line)
+			if not iter.ends_line() or iter.get_char() != '\n':
+				count += 1
+		return count
+	def move_cursor_to_non_empty_line(self, target_line):
+		buffer = self.get_buffer()
+		current_non_empty = 0
+		for line in range(buffer.get_line_count()):
+			iter = buffer.get_iter_at_line(line)
+			if not iter.ends_line() or iter.get_char() != '\n':
+				current_non_empty += 1
+				if current_non_empty == target_line:
+					buffer.place_cursor(iter)
+					self.scroll_to_iter(iter, 0.0, False, 0.0, 0.0)
+					return True
+		return False
 	# For highlighting bookmark position and go-to-line
 	def highlights_cursor_line(self):
 		buffer = self.get_buffer()
 		self.remove_all_highlights()
 		mark = buffer.get_insert()
-		start_iter = buffer.get_iter_at_mark(mark)
-		end_iter = start_iter.copy()
-		end_iter.forward_to_line_end()
-		self.scroll_to_iter(start_iter, 0.0,False,0.0,0.0)
-		buffer.apply_tag(self.highlight_tag, start_iter, end_iter)
+		iter = buffer.get_iter_at_mark(mark)
+		line = iter.get_line()
+		
+		start = buffer.get_iter_at_line(line)
+		end = start.copy()
+		end.forward_to_line_end()
+		
+		self.scroll_to_iter(start, 0.0, False, 0.0, 0.0)
+		buffer.apply_tag(self.highlight_tag, start, end)
 	
 	#Find , Find and Replace , Spell check , TextReader
 	


### PR DESCRIPTION
v1 for #29 
## Recent Changes

### 1. Changed Toolbar Position from Vertical to Horizontal in Text View and Image View
**Reason:** The toolbar positioning on top of the boxes (image and text view) makes more sense because vertically, users would have to click on a side button at the end to view all the tools that were hidden due to space constraints.

### 2. Removed the 4 Buttons (Preferences, Video Tutorials, About, Quit)
**Reason:** These buttons were already present in the "Help" dropdown in the main top toolbar. Removing the duplicate buttons made the UI cleaner.

### 3. Renamed "Update Scanner List" Button to "Detect Scanners"

### 4. Removed "Scan Area" Setting from "Preferences Scanning"

### 5. Added a New `readme.html` File and Updated the "Open Readme" Functionality
**Reason:** Previously, clicking the "Open Readme" button would display the readme in the text view, erasing the pre-existing text. Now, the readme opens in the user's browser, allowing the existing text in the text view to remain intact.

### 6. Changed Home Page Link from SourceForge to the Official Zendalona Website

### 7. Added Line Numbers to Recognized Image's Text in Text View
**Reason:** Users who use LIOS visually may require line numbers as a reference to use the Go-To-Line function.

### 8. Fixed Go-To-Line Functionality
The function now correctly points to the corresponding lines with their correct numbers.

### 9. Added a Button to Show/Hide the X,Y,Width,Height Box
**Reason:** This box is not always required by users, so it now has an option to be hidden, providing more space for the image in image view.
