### PR TITLE
Changing Home Page Link from "http://sourceforge.net/projects/lios/" to "https://www.zendalona.com/lios"

### DIFF
--- a/lios/macros.py
+++ b/lios/macros.py
@@ -61,7 +61,7 @@ app_name_abbreviated = "lios"
 
 source_link = "https://gitlab.com/Nalin-x-Linux/lios-3"
 
-home_page_link = "http://sourceforge.net/projects/lios/"
+home_page_link = "https://www.zendalona.com/lios"
 
 video_tutorials_link = "https://www.youtube.com/playlist?list=PLn29o8rxtRe1zS1r2-yGm1DNMOZCgdU0i"
 


### PR DESCRIPTION
### Changed Home Page Link from SourceForge to the Official Zendalona Website