### PR TITLE
Adding line numbers in a vertical column to the left of the text after recognition in text view.

### DIFF
--- a/lios/editor.py
+++ b/lios/editor.py
@@ -79,7 +79,18 @@ class BasicTextView(text_view.TextView):
 		#while pressing undo or redo that again trigger
 		# insert or delete signals - Nalin.x.GNU
 		self.push_change_to_undobuffer = True;
-	
+	def insert_text_with_line_numbers(self, text):
+		lines = text.split('\n')
+		numbered_lines = []
+		line_number = 1
+		for line in lines:
+			if line.strip():  # Only number non-empty lines
+				numbered_lines.append(f"{line_number}: {line}")
+				line_number += 1
+			else:
+				numbered_lines.append(line)  # Keep empty lines as is
+		self.set_text('\n'.join(numbered_lines))
+		self.set_modified(True)
 	def set_dictionary(self,dict):
 		self.dict = dict
 	

--- a/lios/main.py
+++ b/lios/main.py
@@ -23,7 +23,9 @@ import time
 import shutil
 import re
 from functools import wraps
-
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Pango, PangoCairo
 from lios import scanner, editor, imageview, cam, ocr, preferences, speech
 from lios.ui.gtk import widget, containers, loop, menu, \
 	window, icon_view, dialog, about
@@ -49,7 +51,49 @@ def on_thread(function):
 		threading.Thread(target=function,args=args).start()
 	return inner
 
+class TextViewWithLineNumbers(Gtk.Box):
+    def __init__(self):
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
 
+        self.textview = editor.BasicTextView()
+        self.line_numbers = Gtk.TextView()
+        self.line_numbers.set_editable(False)
+        self.line_numbers.set_cursor_visible(False)
+        self.line_numbers.set_justification(Gtk.Justification.RIGHT)
+
+        # Set a fixed width for the line numbers
+        self.line_numbers.set_size_request(50, -1)  # 50 pixels wide
+
+        # Set monospace font for line numbers
+        font_desc = Pango.FontDescription('Georgia 14')
+        self.line_numbers.override_font(font_desc)
+
+        # Add a separator for visual separation
+        separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+
+        # Pack the widgets into the Box
+        self.pack_start(self.line_numbers, False, False, 0)
+        self.pack_start(separator, False, False, 5)  # 5 pixels space for separation
+        self.pack_start(self.textview, True, True, 0)
+
+        self.textview.get_buffer().connect("changed", self.update_line_numbers)
+        self.textview.connect("size-allocate", self.update_line_numbers)
+
+    def update_line_numbers(self, *args):
+        buffer = self.textview.get_buffer()
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        lines = text.split('\n')
+
+        line_numbers = []
+        number = 1
+        for line in lines:
+            if line.strip():  # Only number non-empty lines
+                line_numbers.append(f"{number:4d}")  # Right-aligned, 4 digits wide
+                number += 1
+            else:
+                line_numbers.append('')  # Empty string for empty lines
+
+        self.line_numbers.get_buffer().set_text('\n'.join(line_numbers))
 class linux_intelligent_ocr_solution():
 	def __init__ (self,file_list=[]):
 		try:
@@ -133,8 +177,8 @@ class linux_intelligent_ocr_solution():
 
 		
 		#Editor
-		self.textview = editor.BasicTextView()
-		self.textview.set_vexpand(True)
+		self.textview_with_lines = TextViewWithLineNumbers()
+		self.textview = self.textview_with_lines.textview
 		self.textview.set_hexpand(True)		
 		self.textview.set_accepts_tab(False)
 		box_editor = containers.Box(containers.Box.HORIZONTAL)
@@ -156,7 +200,7 @@ class linux_intelligent_ocr_solution():
 			])
 		box_editor.add(toolbar_editor)
 		scroll_box_editor = containers.ScrollBox()
-		scroll_box_editor.add(self.textview)
+		scroll_box_editor.add(self.textview_with_lines)
 		box_editor.add(scroll_box_editor)
 
 		#Load TextCleaner List


### PR DESCRIPTION
### Added Line Numbers to Recognized Image's Text in Text View
**Reason:** Users who use LIOS visually may require line numbers as a reference to use the Go-To-Line function.
