### PR TITLE
Fix: Importing PangoCairo Without Specifying Version & Resolve Tesseract Version Path Issues

### DIFF
--- a/lios/ocr/ocr_engine_tesseract.py
+++ b/lios/ocr/ocr_engine_tesseract.py
@@ -24,12 +24,16 @@ from lios.ocr.ocr_engine_base import OcrEngineBase
 TESSDATA_POSSIBLE_PATHS = [
 	"/usr/share/tesseract-ocr/tessdata",
 	"/usr/share/tesseract-ocr/4.00/tessdata",
+	"/usr/share/tesseract-ocr/5.00/tessdata",
+	"/usr/share/tesseract-ocr/5/tessdata,
 	"/usr/share/tesseract/tessdata",
 	"/usr/share/tessdata",
 	"/usr/local/share/tesseract-ocr/tessdata",
 	"/usr/local/share/tesseract/tessdata",
 	"/usr/local/share/tessdata",
-	"/usr/share/tesseract-ocr/4.00/tessdata" ]
+	"/usr/share/tesseract-ocr/4.00/tessdata",
+	"/usr/share/tesseract-ocr/5.00/tessdata",
+	"/usr/share/tesseract-ocr/5/tessdata"]
 
 TESSDATA_EXTENSION = ".traineddata"
 

--- a/lios/ui/gtk/print_dialog.py
+++ b/lios/ui/gtk/print_dialog.py
@@ -20,7 +20,7 @@
 
 import gi
 gi.require_version("Gtk", "3.0")
-
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import Gtk
 from gi.repository import Pango
 from gi.repository import PangoCairo


### PR DESCRIPTION
PangoCairo Import Improvement:
The module can now be imported without explicitly specifying the version, ensuring better compatibility and reducing potential import errors.

Tesseract Version Path Fix:
Adjustments have been made to properly detect and use the correct Tesseract version path, resolving previous path-related issues.