### PR TITLE
Fix uninitialized variable error in cam.py

### DIFF
--- a/lios/cam.py
+++ b/lios/cam.py
@@ -26,6 +26,8 @@ from gi.repository import Gtk
 from gi.repository import Gst
 from gi.repository import Gdk
 from gi.repository import GObject
+from lios import localization
+_ = localization._
 
 import datetime
 import os.path


### PR DESCRIPTION
This was introduced in 5d472327488362e234c3cf8e7d2e97ddcbd6b5b6