### PR TITLE
Fix invisible toolbar dropdown items

### DIFF
--- a/lios/ui/gtk/containers.py
+++ b/lios/ui/gtk/containers.py
@@ -157,6 +157,9 @@ class Toolbar(Gtk.Toolbar):
 					if(orientation == Gtk.Orientation.VERTICAL):
 						label.set_angle(90)
 					toolbar_item.set_icon_widget(label)
+				display_text = ' '.join(item[0].split("-"))
+				label = Gtk.Label(display_text)
+				toolbar_item.set_label_widget(label)
 				toolbar_item.set_tooltip_text(item[0])
 			self.add(toolbar_item)
 	


### PR DESCRIPTION
Added Labels to reflect the property of the item in the toolbar

### Before: 

![Screenshot from 2025-03-02 16-34-19](https://github.com/user-attachments/assets/2c7be511-3165-4acc-85ef-141d58ae26e9)


### After: 

![Screenshot from 2025-03-02 16-29-15](https://github.com/user-attachments/assets/f8b8b916-a847-4a65-ac0c-d53bf8246eaf)
