### PR TITLE
Fix a typo in ocr_engine_tesseract.py

### DIFF
--- a/lios/ocr/ocr_engine_tesseract.py
+++ b/lios/ocr/ocr_engine_tesseract.py
@@ -25,7 +25,7 @@ TESSDATA_POSSIBLE_PATHS = [
 	"/usr/share/tesseract-ocr/tessdata",
 	"/usr/share/tesseract-ocr/4.00/tessdata",
 	"/usr/share/tesseract-ocr/5.00/tessdata",
-	"/usr/share/tesseract-ocr/5/tessdata,
+	"/usr/share/tesseract-ocr/5/tessdata",
 	"/usr/share/tesseract/tessdata",
 	"/usr/share/tessdata",
 	"/usr/local/share/tesseract-ocr/tessdata",


### PR DESCRIPTION
- Added a missing comma in the path `/usr/share/tesseract-ocr/5/tessdata`