### PR TITLE
Fixed PDF export issue for images

### DIFF
--- a/lios/main.py
+++ b/lios/main.py
@@ -1260,6 +1260,8 @@ class linux_intelligent_ocr_solution():
 		response = dlg.run()
 		if response == FileChooserDialog.ACCEPT:
 			file_name = dlg.get_filename()
+			if not file_name.lower().endswith(".pdf"):
+				file_name += ".pdf"
 			command = "convert " 
 			for item in self.iconview.get_selected_item_names():
 				command += item + " "


### PR DESCRIPTION
Fixed an issue where if the user forgot to add the _.pdf_ extension at the end of the filename, the exported PDF file would be saved as an image file. Now, the _.pdf_ extension is automatically added if missing.
 
This fix ensures that the exported PDF is saved with the correct file extension, preventing it from being mistakenly treated as an image file when the extension is omitted.

How to test:
go to -> _Image_ -> _Export As Pdf_ -> save the file
![Export As Pdf](https://github.com/user-attachments/assets/54ecc492-4755-4a29-94b3-03978943f942)

Try exporting without adding the _.pdf_ extension to the filename and verify that the file is saved correctly with the _.pdf_ extension.