### PR TITLE
Fixed exporting Text as PDF

### DIFF
--- a/lios/editor.py
+++ b/lios/editor.py
@@ -834,16 +834,20 @@ class BasicTextView(text_view.TextView):
 			text = self.get_text()
 		print_dialog.print_with_action(text,print_dialog.print_with_action.PRINT_DIALOG)		
 		
-	def print_to_pdf(self,*data):
-		save_file = file_chooser.FileChooserDialog(_("Enter the file name"),
-			file_chooser.FileChooserDialog.SAVE,macros.supported_pdf_formats,macros.user_home_path)
+	def print_to_pdf(self, *data):
+		save_file = file_chooser.FileChooserDialog(
+			_("Enter the file name"), file_chooser.FileChooserDialog.SAVE,
+			macros.supported_pdf_formats, macros.user_home_path)
 		response = save_file.run()
 		if response == file_chooser.FileChooserDialog.ACCEPT:
+			file_name = save_file.get_filename()
+			if not file_name.lower().endswith(".pdf"):
+				file_name += ".pdf"
 			if (self.has_selection()):
 				text = self.get_selected_text()
 			else:
 				text = self.get_text()
-			print_dialog.print_with_action(text,print_dialog.print_with_action.EXPORT,
-				save_file.get_filename())
+			print_dialog.print_with_action(
+				text, print_dialog.print_with_action.EXPORT, file_name)
 			save_file.destroy()
 


### PR DESCRIPTION
Added a check to ensure that the `.pdf` extension is automatically appended to the filename when exporting text as a PDF.
This resolves an issue where users could save the file without the `.pdf` extension, which might cause problems when opening the file later.
  
### Testing
Go to -> File -> Export-Text-As-Pdf
Save the file with any name (without `.pdf`)
![vlcsnap-2025-03-22-18h52m32s072](https://github.com/user-attachments/assets/f668831f-d1b1-4e5f-94bf-0073a1283c96)


The file will now be automatically saved with the `.pdf` extension, ensuring proper file format.

This change improves usability and prevents errors related to file extensions.